### PR TITLE
appdata: Remove <suggests> with empty <id>

### DIFF
--- a/org.cubocore.CoreImage.appdata.xml
+++ b/org.cubocore.CoreImage.appdata.xml
@@ -62,8 +62,4 @@
             <image type="source">https://gitlab.com/cubocore/wiki/-/raw/master/screenshots/coreimage/coreimage-flatpak-kde.png</image>
         </screenshot>
     </screenshots>
-
-    <suggests>
-        <id></id>
-    </suggests>
 </component>


### PR DESCRIPTION
This isn't valid AppStream metadata, and causes appstream-glib to
spam critical warnings (flatpak/flatpak#4219).